### PR TITLE
Fix handling of merkle block messages:

### DIFF
--- a/wallet-kit/src/main/kotlin/bitcoin/wallet/kit/core/Extensions.kt
+++ b/wallet-kit/src/main/kotlin/bitcoin/wallet/kit/core/Extensions.kt
@@ -1,0 +1,13 @@
+package bitcoin.wallet.kit.core
+
+fun ByteArray.toHexString(): String {
+    return this.joinToString(separator = "") {
+        it.toInt().and(0xff).toString(16).padStart(2, '0')
+    }
+}
+
+fun String.hexStringToByteArray(): ByteArray {
+    return ByteArray(this.length / 2) {
+        this.substring(it * 2, it * 2 + 2).toInt(16).toByte()
+    }
+}

--- a/wallet-kit/src/main/kotlin/bitcoin/wallet/kit/models/MerkleBlock.kt
+++ b/wallet-kit/src/main/kotlin/bitcoin/wallet/kit/models/MerkleBlock.kt
@@ -1,5 +1,6 @@
 package bitcoin.wallet.kit.models
 
+import bitcoin.wallet.kit.core.toHexString
 import bitcoin.wallet.kit.exceptions.InvalidMerkleBlockException
 import bitcoin.wallet.kit.utils.MerkleBranch
 import bitcoin.walllet.kit.io.BitcoinInput
@@ -22,8 +23,8 @@ class MerkleBlock(input: BitcoinInput) {
     var hashes: Array<ByteArray> = arrayOf()
     var flags: ByteArray = byteArrayOf()
 
-    var associatedTransactionHashes: MutableList<ByteArray> = mutableListOf()
-    val associatedTransactions: MutableList<Transaction> = mutableListOf()
+    var associatedTransactionHexes = listOf<String>()
+    val associatedTransactions = mutableListOf<Transaction>()
     val blockHash: ByteArray by lazy {
         HashUtils.doubleSha256(header.toByteArray())
     }
@@ -58,7 +59,10 @@ class MerkleBlock(input: BitcoinInput) {
 
         flags = input.readBytes(flagsCount.toInt())
 
-        val merkleRoot = MerkleBranch(txCount, hashes, flags).calculateMerkleRoot(associatedTransactionHashes)
+        val matchedHashes = mutableListOf<ByteArray>()
+        val merkleRoot = MerkleBranch(txCount, hashes, flags).calculateMerkleRoot(matchedHashes)
+        associatedTransactionHexes = matchedHashes.map { it.toHexString() }
+
         if (!header.merkleHash.contentEquals(merkleRoot)) {
             throw InvalidMerkleBlockException("Merkle root is not valid")
         }

--- a/wallet-kit/src/test/kotlin/bitcoin/wallet/kit/message/MerkleBlockMessageTest.kt
+++ b/wallet-kit/src/test/kotlin/bitcoin/wallet/kit/message/MerkleBlockMessageTest.kt
@@ -27,7 +27,7 @@ class MerkleBlockMessageTest {
         val merkleBlock = message.merkleBlock
 
         Assert.assertEquals(expectedBlockHash, TestHelper.byteArrayToHex(merkleBlock.blockHash))
-        Assert.assertArrayEquals(expectedTransactionHashes, merkleBlock.associatedTransactionHashes.map { TestHelper.byteArrayToHex(it) }.toTypedArray())
+        Assert.assertArrayEquals(expectedTransactionHashes, merkleBlock.associatedTransactionHexes.toTypedArray())
     }
 
 }


### PR DESCRIPTION
 - Replace ByteArray with HexString for comparison
 - Update tests to use copies of ByteArray in mocks. Using the same ByteArray objects in mocks make tests pass whereas they should not.